### PR TITLE
feat: implementar dashboard con KPIs y métricas operativas

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -42,7 +42,7 @@ class DashboardController extends Controller
 
         $topDepartamentos = (clone $activosActivos)
             ->select('departamento_id', DB::raw('COUNT(*) as total'))
-            ->with('departamento:id,nombre')
+            ->with('departamento:id,nombreDepartamento')
             ->groupBy('departamento_id')
             ->orderByDesc('total')
             ->take(5)

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Activo;
+use App\Models\Cliente;
+use App\Models\Departamento;
+use App\Models\Producto;
+use Illuminate\Contracts\View\View;
+use Illuminate\Support\Facades\DB;
+
+class DashboardController extends Controller
+{
+    public function __invoke(): View
+    {
+        $activosActivos = Activo::query()->where('estado', true);
+
+        $kpis = [
+            'total_activos' => (clone $activosActivos)->count(),
+            'activos_disponibles' => (clone $activosActivos)->where('estadoActivo', 'Disponible')->count(),
+            'activos_asignados' => (clone $activosActivos)->where('estadoActivo', 'Asignado')->count(),
+            'activos_en_reparacion' => (clone $activosActivos)->where('estadoActivo', 'Reparacion')->count(),
+            'activos_descartados' => (clone $activosActivos)->where('estadoActivo', 'Descartado')->count(),
+            'garantias_vigentes' => (clone $activosActivos)
+                ->where('garantia', true)
+                ->whereDate('fecha_final_garantia', '>=', now()->toDateString())
+                ->count(),
+            'garantias_vencidas' => (clone $activosActivos)
+                ->where('garantia', true)
+                ->whereDate('fecha_final_garantia', '<', now()->toDateString())
+                ->count(),
+            'clientes_activos' => Cliente::query()->where('estado', true)->count(),
+            'productos_activos' => Producto::query()->where('estadoProductos', true)->count(),
+            'departamentos_activos' => Departamento::query()->where('estado', true)->count(),
+        ];
+
+        $activosPorEstado = (clone $activosActivos)
+            ->select('estadoActivo', DB::raw('COUNT(*) as total'))
+            ->groupBy('estadoActivo')
+            ->orderByDesc('total')
+            ->get();
+
+        $topDepartamentos = (clone $activosActivos)
+            ->select('departamento_id', DB::raw('COUNT(*) as total'))
+            ->with('departamento:id,nombre')
+            ->groupBy('departamento_id')
+            ->orderByDesc('total')
+            ->take(5)
+            ->get();
+
+        $activosPorCiudad = (clone $activosActivos)
+            ->select('ciudad', DB::raw('COUNT(*) as total'))
+            ->whereNotNull('ciudad')
+            ->groupBy('ciudad')
+            ->orderByDesc('total')
+            ->get();
+
+        return view('dashboard', [
+            'kpis' => $kpis,
+            'activosPorEstado' => $activosPorEstado,
+            'topDepartamentos' => $topDepartamentos,
+            'activosPorCiudad' => $activosPorCiudad,
+        ]);
+    }
+}

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -70,7 +70,7 @@
                     <ul class="space-y-3">
                         @forelse ($topDepartamentos as $departamento)
                             <li class="flex items-center justify-between border-b pb-2">
-                                <span class="text-gray-600">{{ $departamento->departamento?->nombre ?? 'Sin departamento' }}</span>
+                                <span class="text-gray-600">{{ $departamento->departamento?->nombreDepartamento ?? 'Sin departamento' }}</span>
                                 <span class="font-semibold text-gray-900">{{ $departamento->total }}</span>
                             </li>
                         @empty

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -5,11 +5,92 @@
         </h2>
     </x-slot>
 
-    <div class="py-12">
-        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
-            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
-                <div class="p-6 text-gray-900">
-                    {{ __("You're logged in!") }}
+    <div class="py-8">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8 space-y-6">
+            <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+                <div class="bg-white shadow-sm sm:rounded-lg p-5">
+                    <p class="text-sm text-gray-500">Total activos</p>
+                    <p class="text-3xl font-bold text-gray-900">{{ $kpis['total_activos'] }}</p>
+                </div>
+                <div class="bg-white shadow-sm sm:rounded-lg p-5">
+                    <p class="text-sm text-gray-500">Activos disponibles</p>
+                    <p class="text-3xl font-bold text-emerald-600">{{ $kpis['activos_disponibles'] }}</p>
+                </div>
+                <div class="bg-white shadow-sm sm:rounded-lg p-5">
+                    <p class="text-sm text-gray-500">Activos asignados</p>
+                    <p class="text-3xl font-bold text-blue-600">{{ $kpis['activos_asignados'] }}</p>
+                </div>
+                <div class="bg-white shadow-sm sm:rounded-lg p-5">
+                    <p class="text-sm text-gray-500">En reparación</p>
+                    <p class="text-3xl font-bold text-amber-600">{{ $kpis['activos_en_reparacion'] }}</p>
+                </div>
+                <div class="bg-white shadow-sm sm:rounded-lg p-5">
+                    <p class="text-sm text-gray-500">Activos descartados</p>
+                    <p class="text-3xl font-bold text-rose-600">{{ $kpis['activos_descartados'] }}</p>
+                </div>
+                <div class="bg-white shadow-sm sm:rounded-lg p-5">
+                    <p class="text-sm text-gray-500">Garantías vigentes</p>
+                    <p class="text-3xl font-bold text-indigo-600">{{ $kpis['garantias_vigentes'] }}</p>
+                </div>
+                <div class="bg-white shadow-sm sm:rounded-lg p-5">
+                    <p class="text-sm text-gray-500">Garantías vencidas</p>
+                    <p class="text-3xl font-bold text-rose-600">{{ $kpis['garantias_vencidas'] }}</p>
+                </div>
+                <div class="bg-white shadow-sm sm:rounded-lg p-5">
+                    <p class="text-sm text-gray-500">Clientes activos</p>
+                    <p class="text-3xl font-bold text-gray-900">{{ $kpis['clientes_activos'] }}</p>
+                </div>
+                <div class="bg-white shadow-sm sm:rounded-lg p-5 sm:col-span-2 lg:col-span-2">
+                    <p class="text-sm text-gray-500">Productos activos</p>
+                    <p class="text-3xl font-bold text-gray-900">{{ $kpis['productos_activos'] }}</p>
+                </div>
+                <div class="bg-white shadow-sm sm:rounded-lg p-5 sm:col-span-2 lg:col-span-2">
+                    <p class="text-sm text-gray-500">Departamentos activos</p>
+                    <p class="text-3xl font-bold text-gray-900">{{ $kpis['departamentos_activos'] }}</p>
+                </div>
+            </div>
+
+            <div class="grid grid-cols-1 lg:grid-cols-3 gap-6">
+                <div class="bg-white shadow-sm sm:rounded-lg p-5 lg:col-span-1">
+                    <h3 class="text-lg font-semibold text-gray-900 mb-4">Activos por estado</h3>
+                    <ul class="space-y-3">
+                        @forelse ($activosPorEstado as $estado)
+                            <li class="flex items-center justify-between border-b pb-2">
+                                <span class="text-gray-600">{{ $estado->estadoActivo }}</span>
+                                <span class="font-semibold text-gray-900">{{ $estado->total }}</span>
+                            </li>
+                        @empty
+                            <li class="text-sm text-gray-500">Sin datos disponibles.</li>
+                        @endforelse
+                    </ul>
+                </div>
+
+                <div class="bg-white shadow-sm sm:rounded-lg p-5 lg:col-span-1">
+                    <h3 class="text-lg font-semibold text-gray-900 mb-4">Top departamentos</h3>
+                    <ul class="space-y-3">
+                        @forelse ($topDepartamentos as $departamento)
+                            <li class="flex items-center justify-between border-b pb-2">
+                                <span class="text-gray-600">{{ $departamento->departamento?->nombre ?? 'Sin departamento' }}</span>
+                                <span class="font-semibold text-gray-900">{{ $departamento->total }}</span>
+                            </li>
+                        @empty
+                            <li class="text-sm text-gray-500">Sin datos disponibles.</li>
+                        @endforelse
+                    </ul>
+                </div>
+
+                <div class="bg-white shadow-sm sm:rounded-lg p-5 lg:col-span-1">
+                    <h3 class="text-lg font-semibold text-gray-900 mb-4">Activos por ciudad</h3>
+                    <ul class="space-y-3">
+                        @forelse ($activosPorCiudad as $ciudad)
+                            <li class="flex items-center justify-between border-b pb-2">
+                                <span class="text-gray-600">{{ $ciudad->ciudad }}</span>
+                                <span class="font-semibold text-gray-900">{{ $ciudad->total }}</span>
+                            </li>
+                        @empty
+                            <li class="text-sm text-gray-500">Sin datos disponibles.</li>
+                        @endforelse
+                    </ul>
                 </div>
             </div>
         </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\ActivoController;
 use App\Http\Controllers\CategoriasController;
+use App\Http\Controllers\DashboardController;
 use App\Http\Controllers\ClientesController;
 use App\Http\Controllers\DepartamentosController;
 use App\Http\Controllers\MarcasController;
@@ -25,9 +26,7 @@ Route::get('/', function () {
     return view('welcome');
 });
 
-Route::get('/dashboard', function () {
-    return view('dashboard');
-})->middleware(['auth', 'verified'])->name('dashboard');
+Route::get('/dashboard', DashboardController::class)->middleware(['auth', 'verified'])->name('dashboard');
 
 Route::middleware('auth')->group(function () {
     Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');

--- a/tests/Feature/DashboardTest.php
+++ b/tests/Feature/DashboardTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class DashboardTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_dashboard_requires_authentication(): void
+    {
+        $response = $this->get(route('dashboard'));
+
+        $response->assertRedirect(route('login'));
+    }
+
+    public function test_authenticated_verified_user_can_view_dashboard(): void
+    {
+        $user = User::factory()->create([
+            'email_verified_at' => now(),
+        ]);
+
+        $response = $this->actingAs($user)->get(route('dashboard'));
+
+        $response->assertOk();
+        $response->assertSee('Total activos');
+        $response->assertSee('Activos por estado');
+    }
+}


### PR DESCRIPTION
### Motivation
- Centralizar la lógica del dashboard en un controlador y ofrecer un tablero con KPIs operativos relevantes para gestión de activos, manteniendo la estructura de controladores, rutas y middlewares del proyecto.

### Description
- Se agregó `DashboardController` invocable que calcula KPIs (total de activos, disponibles, asignados, en reparación, descartados, garantías vigentes/vencidas, clientes/productos/departamentos activos) y agrega agregados por estado, ciudad y top 5 departamentos.
- Se reemplazó la ruta closure de `/dashboard` por el controlador (`Route::get('/dashboard', DashboardController::class)`) manteniendo `auth` y `verified`.
- Se rediseñó `resources/views/dashboard.blade.php` con tarjetas KPI y secciones de listas para "Activos por estado", "Top departamentos" y "Activos por ciudad", incluyendo manejo de estados vacíos.
- Se añadió la prueba de feature `tests/Feature/DashboardTest.php` que valida redirección para usuarios no autenticados y visualización para usuario autenticado y verificado.

### Testing
- Se ejecutó `php -l` sobre `app/Http/Controllers/DashboardController.php`, `routes/web.php` y `tests/Feature/DashboardTest.php` y no se detectaron errores de sintaxis (OK).
- `php artisan test` no pudo ejecutarse porque `vendor/` falta y `composer install` falló por incompatibilidad de la lockfile con la versión de PHP del entorno (dependencias bloqueadas no compatibles con PHP 8.5.x) (FALLÓ).
- Se generó una evidencia visual del nuevo dashboard mediante un script de navegador y se guardó en `browser:/tmp/codex_browser_invocations/9b5245c68c613c9f/artifacts/artifacts/dashboard.png` (OK).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4994b38788322889c4ac6eeef15fc)